### PR TITLE
Move to static data

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -64,15 +64,7 @@ export default function Home({ featuredRepoData, repoData, postData }: Props) {
           </div>
           <div>
             <List
-              items={repoData.sort((a: Repository, b: Repository) => {
-                if (typeof a.stargazers_count === 'undefined')
-                  a.stargazers_count = 0;
-
-                if (typeof b.stargazers_count === 'undefined')
-                  b.stargazers_count = 0;
-
-                return a.stargazers_count > b.stargazers_count ? -1 : 1;
-              })}
+              items={repoData}
               renderItem={ProjectCard}
               className={s.contentList}
             />
@@ -101,23 +93,14 @@ export default function Home({ featuredRepoData, repoData, postData }: Props) {
   );
 }
 
-export const getServerSideProps = async () => {
-  // TODO reduce endpoint hits on DEV
-  const dataDirectory = path.join(process.cwd(), 'src/__mocks__');
-  let repoData, postData;
+export const getStaticProps = async () => {
+  const dataDirectory = path.join(process.cwd(), 'src/data');
+  let postData;
   if (process.env.NODE_ENV === 'development') {
-    repoData = JSON.parse(
-      fs.readFileSync('src/__mocks__/repos.json').toString()
-    );
     postData = JSON.parse(
       fs.readFileSync('src/__mocks__/posts.json').toString()
     );
   } else {
-    const repoResponse = await fetch(
-      'https://api.github.com/users/nhevia/repos'
-    );
-    repoData = await repoResponse.json();
-
     // TODO need standarized data to combine different sources (markdown, dev.to, etc)
     const postResponse = await fetch(
       'https://dev.to/api/articles?username=nicoh'
@@ -127,6 +110,9 @@ export const getServerSideProps = async () => {
 
   const featuredRepoData = JSON.parse(
     fs.readFileSync(`${dataDirectory}/reposfeatured.json`).toString()
+  );
+  const repoData = JSON.parse(
+    fs.readFileSync(`${dataDirectory}/repos.json`).toString()
   );
 
   return {

--- a/src/components/items/ProjectCard/ProjectCard.tsx
+++ b/src/components/items/ProjectCard/ProjectCard.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 import Repo from 'public/icons/repo.svg';
-import Star from 'public/icons/star.svg';
-import Fork from 'public/icons/fork.svg';
 import { getLanguageColor } from 'utils/colors';
 import { Repository } from 'types/items';
 import s from './ProjectCard.module.css';
@@ -12,8 +10,6 @@ const ProjectCard = ({
   description,
   html_url,
   language,
-  stargazers_count,
-  forks,
 }: Repository) => {
   return (
     <div key={id} className={s.root} aria-label="repository summary">
@@ -52,15 +48,6 @@ const ProjectCard = ({
             }
           />
           <span data-testid="language">{language}</span>
-        </span>
-        <span className={s.section}>
-          <span>
-            <Star />
-          </span>
-          <span data-testid="stargazers">{stargazers_count}</span>
-        </span>
-        <span className={s.section} data-testid="forks">
-          <Fork /> {forks}
         </span>
       </div>
     </div>

--- a/src/data/repos.json
+++ b/src/data/repos.json
@@ -1,0 +1,51 @@
+[
+  {
+    "id": 206913932,
+    "name": "ctvee",
+    "full_name": "nhevia/ctvee",
+    "html_url": "https://github.com/nhevia/ctvee",
+    "description": "Site to query your favourite series",
+    "created_at": "2019-09-07T04:11:07Z",
+    "language": "JavaScript",
+    "topics": ["react"]
+  },
+  {
+    "id": 333836136,
+    "name": "discord-styled-releases",
+    "full_name": "nhevia/discord-styled-releases",
+    "html_url": "https://github.com/nhevia/discord-styled-releases",
+    "description": "Add this action to send styled messages to a Discord server. New releases get sent automatically",
+    "created_at": "2021-01-28T17:38:27Z",
+    "language": "JavaScript",
+    "topics": ["discord", "discord-webhook", "github-actions", "patch-notes"]
+  },
+  {
+    "id": 480193749,
+    "name": "react-state",
+    "full_name": "nhevia/react-state",
+    "html_url": "https://github.com/nhevia/react-state",
+    "description": "Playground that showcases different ways to use state managers with react (context, RTL, Jotai, Zustand, etc)",
+    "created_at": "2022-04-11T02:00:30Z",
+    "language": "JavaScript"
+  },
+  {
+    "id": 290752819,
+    "name": "simple-docs",
+    "full_name": "nhevia/simple-docs",
+    "html_url": "https://github.com/nhevia/simple-docs",
+    "description": "Simple documentation tool",
+    "created_at": "2020-08-27T11:03:44Z",
+    "language": "JavaScript",
+    "topics": ["documentation", "documentation-generator", "documentation-tool"]
+  },
+  {
+    "id": 504182485,
+    "name": "xscaffold",
+    "full_name": "nhevia/xscaffold",
+    "html_url": "https://github.com/nhevia/xscaffold",
+    "description": "Everything installed & configured (next.js, TS, Jest, linting, etc) to scaffold a new project. Missed chance to call it \"xcaffold\"",
+    "created_at": "2022-06-16T14:14:07Z",
+    "language": "TypeScript",
+    "topics": ["nextjs", "scaffolder"]
+  }
+]

--- a/src/data/reposfeatured.json
+++ b/src/data/reposfeatured.json
@@ -1,0 +1,22 @@
+[
+  {
+    "title": "The Source",
+    "description": "A social media site for a well-known online RPG video game. This project features accounts, events management, media, filters, tags, favourites, calendar, profile integration, themes and more.",
+    "image": "https://thesourceimages.nyc3.cdn.digitaloceanspaces.com/site/blog/thesource_thumb.jpg",
+    "demo_url": "https://www.thesource.fun"
+  },
+  {
+    "title": "xMarket",
+    "description": "A fully working e-commerce site with categories, filters, cart, checkout process and themes, ready to be used as a real store. Made with Next.js and TypeScript, it features full testing coverage, global store (Zustand), css-modules and Stripe integration.",
+    "image": "https://thesourceimages.nyc3.cdn.digitaloceanspaces.com/site/blog/xmarket_thumb.jpg",
+    "demo_url": "https://xmarket-nhevia.vercel.app",
+    "code_url": "https://github.com/nhevia/xmarket"
+  },
+  {
+    "title": "Smart Trader",
+    "description": "A software executable (made with Electron.js) that works as an interface for a well-known crypto exchanger. It features adjusted auto buy/sell placements and live tracking.",
+    "image": "https://thesourceimages.nyc3.cdn.digitaloceanspaces.com/site/blog/smarttrader_thumb.jpg",
+    "demo_url": "https://github.com/nhevia/smart-trader/releases",
+    "code_url": "https://github.com/nhevia/smart-trader"
+  }
+]

--- a/src/types/items.ts
+++ b/src/types/items.ts
@@ -7,13 +7,14 @@ export interface ProjectFeatured {
 }
 
 export interface Repository {
-  full_name?: string;
-  description?: string;
-  html_url?: string;
-  language?: string;
-  stargazers_count?: number;
-  forks?: number;
-  id?: number;
+  id: number;
+  name: string;
+  full_name: string;
+  html_url: string;
+  description: string;
+  created_at: string;
+  language: string;
+  topics?: string[];
 }
 
 export interface Post {


### PR DESCRIPTION
No need to fetch data from github repositories since they'll be separated into featured/others. Apply SSG instead of SSR for all prefetched data.

Only case that still needs data to be fetched is blogpost, but it'll use incremental static generation (for now).